### PR TITLE
deps: updates wazero to 1.0.0-pre.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,4 @@ module wazerolib
 
 go 1.18
 
-require github.com/tetratelabs/wazero v1.0.0-pre.1
-
-replace github.com/tetratelabs/wazero => ../wazero
+require github.com/tetratelabs/wazero v1.0.0-pre.3

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/tetratelabs/wazero v1.0.0-pre.3 h1:Z5fbogMUGcERzaQb9mQU8+yJSy0bVvv2ce3dfR4wcZg=
+github.com/tetratelabs/wazero v1.0.0-pre.3/go.mod h1:M8UDNECGm/HVjOfq0EOe4QfCY9Les1eq54IChMLETbc=

--- a/wazerolib/lib.go
+++ b/wazerolib/lib.go
@@ -29,10 +29,10 @@ func allowedErrorDuringInstantiation(errMsg string) bool {
 	return false
 }
 
-//export run_wazero
-//
 // run_wazero ensures that the behavior is the same between the compiler and the interpreter for any given
 // binary.
+//
+//export run_wazero
 func run_wazero(binaryPtr uintptr, binarySize int, watPtr uintptr, watSize int) {
 	wasmBin := *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
 		Data: binaryPtr,
@@ -50,8 +50,8 @@ func run_wazero(binaryPtr uintptr, binarySize int, watPtr uintptr, watSize int) 
 	ctx := context.Background()
 
 	// Create two runtimes.
-	interpreter := wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfigInterpreter().WithWasmCore2())
-	compiler := wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfigCompiler().WithWasmCore2())
+	interpreter := wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfigInterpreter())
+	compiler := wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfigCompiler())
 
 	defer compiler.Close(ctx)
 	defer interpreter.Close(ctx)
@@ -62,12 +62,12 @@ func run_wazero(binaryPtr uintptr, binarySize int, watPtr uintptr, watSize int) 
 			saveFailedBinary(wasmBin, wat)
 		}
 	}()
-	compiledCompiled, err := compiler.CompileModule(ctx, wasmBin, wazero.NewCompileConfig())
+	compiledCompiled, err := compiler.CompileModule(ctx, wasmBin)
 	if err != nil {
 		panic(err)
 	}
 
-	interpreterCompiled, err := interpreter.CompileModule(ctx, wasmBin, wazero.NewCompileConfig())
+	interpreterCompiled, err := interpreter.CompileModule(ctx, wasmBin)
 	if err != nil {
 		panic(err)
 	}

--- a/wazerolib/lib_test.go
+++ b/wazerolib/lib_test.go
@@ -20,16 +20,16 @@ func TestReRunFailedCase(t *testing.T) {
 	// Choose the context to use for function calls.
 	ctx := context.Background()
 
-	compiler := wazero.NewRuntimeWithConfig(wazero.NewRuntimeConfigCompiler().WithWasmCore2())
-	interpreter := wazero.NewRuntimeWithConfig(wazero.NewRuntimeConfigInterpreter().WithWasmCore2())
+	compiler := wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfigCompiler())
+	interpreter := wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfigInterpreter())
 
 	// Compile module.
-	compiledCompiled, err := compiler.CompileModule(ctx, wasmBin, wazero.NewCompileConfig())
+	compiledCompiled, err := compiler.CompileModule(ctx, wasmBin)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	interpreterCompiled, err := interpreter.CompileModule(ctx, wasmBin, wazero.NewCompileConfig())
+	interpreterCompiled, err := interpreter.CompileModule(ctx, wasmBin)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.0-pre.3](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.3). Note: wazero 1.0 will require Go 1.18+

Notably, this improves performance and changes host function syntax.